### PR TITLE
Setting up pycodestyle and linted default_settings.py and urls.py for PEP8

### DIFF
--- a/danceschool/default_settings.py
+++ b/danceschool/default_settings.py
@@ -13,7 +13,7 @@ import sys
 from os import path
 
 # Required for Django CMS.  Override in your own settings.py
-LANGUAGES = [('en', 'English'),]
+LANGUAGES = [('en', 'English'), ]
 
 # Override in settings.py to add your own templates, or override the
 # defaults directly by placing templates with the same name in a
@@ -58,7 +58,7 @@ CKEDITOR_IMAGE_BACKEND = 'pillow'
 CKEDITOR_SETTINGS = {
     'language': '',
     'toolbar_CMS': [
-        {'name': 'basicstyles','items': ['Bold', 'Italic', 'Underline', '-', 'RemoveFormat']},
+        {'name': 'basicstyles', 'items': ['Bold', 'Italic', 'Underline', '-', 'RemoveFormat']},
         {'name': 'clipboard', 'items': ['Cut', 'Copy', 'Paste', 'PasteText', '-', 'Undo', 'Redo']},
         {
             'name': 'paragraph',
@@ -68,11 +68,11 @@ CKEDITOR_SETTINGS = {
         {'name': 'styles', 'items': ['Format']},
         '/',
         {'name': 'links', 'items': ['Link', 'Unlink', 'Anchor']},
-        {'name': 'insert','items': ['FilerImage','Table', 'HorizontalRule', 'Smiley', 'Iframe']},
-        {'name': 'tools', 'items': ['Maximize', 'ShowBlocks','Source']},
+        {'name': 'insert', 'items': ['FilerImage', 'Table', 'HorizontalRule', 'Smiley', 'Iframe']},
+        {'name': 'tools', 'items': ['Maximize', 'ShowBlocks', 'Source']},
     ],
     'toolbar_HTMLField': [
-        {'name': 'basicstyles','items': ['Bold', 'Italic', 'Underline', '-', 'RemoveFormat']},
+        {'name': 'basicstyles', 'items': ['Bold', 'Italic', 'Underline', '-', 'RemoveFormat']},
         {'name': 'clipboard', 'items': ['Cut', 'Copy', 'Paste', 'PasteText', '-', 'Undo', 'Redo']},
         {
             'name': 'paragraph',
@@ -82,8 +82,8 @@ CKEDITOR_SETTINGS = {
         {'name': 'styles', 'items': ['Format']},
         '/',
         {'name': 'links', 'items': ['Link', 'Unlink', 'Anchor']},
-        {'name': 'insert','items': ['FilerImage','Table', 'HorizontalRule', 'Smiley', 'Iframe']},
-        {'name': 'tools', 'items': ['Maximize', 'ShowBlocks','Source']},
+        {'name': 'insert', 'items': ['FilerImage', 'Table', 'HorizontalRule', 'Smiley', 'Iframe']},
+        {'name': 'tools', 'items': ['Maximize', 'ShowBlocks', 'Source']},
     ],
     'skin': 'moono',
     'extraPlugins': ','.join(
@@ -108,7 +108,7 @@ HUEY = SqliteHuey(
     filename=path.join(
         path.dirname(
             path.abspath(
-                getattr(sys.modules['__main__'],'__file__',path.dirname(__file__)),
+                getattr(sys.modules['__main__'], '__file__', path.dirname(__file__)),
             )
         ),
         'huey.sqlite3'
@@ -126,5 +126,5 @@ CRISPY_FAIL_SILENTLY = True
 DJANGOCMS_FORMS_PLUGIN_MODULE = 'Forms'
 DJANGOCMS_FORMS_TEMPLATES = (
     ('djangocms_forms/form_template/default.html', 'Default'),
-    ('forms/djangocms_forms_crispy.html','Crispy Form (recommended)'),
+    ('forms/djangocms_forms_crispy.html', 'Crispy Form (recommended)'),
 )

--- a/danceschool/setup.cfg
+++ b/danceschool/setup.cfg
@@ -1,0 +1,2 @@
+[pycodestyle]
+max-line-length = 120

--- a/danceschool/urls.py
+++ b/danceschool/urls.py
@@ -19,19 +19,27 @@ urlpatterns = [
             form_class=GlobalPreferenceForm,
             template_name='dynamic_preferences/form_danceschool.html',)),
         name="dynamic_preferences.global"),
+
     url(r'^settings/global/(?P<section>[\w\ ]+)$',
         user_passes_test(lambda u: u.is_superuser)(PreferenceFormView.as_view(
             registry=global_preferences_registry,
             form_class=GlobalPreferenceForm,
             template_name='dynamic_preferences/form_danceschool.html',)),
         name="dynamic_preferences.global.section"),
+
     # For Django-filer
     url(r'^filer/', include('filer.urls')),
     url(r'^', include('filer.server.urls')),
+
     # For Django-filer in CKeditor
     url(r'^filebrowser_filer/', include('ckeditor_filebrowser_filer.urls')),
+
     # For automatically-generated sitemaps
-    url(r'^sitemap\.xml$', sitemap, {'sitemaps': {'event': EventSitemap, 'page': CMSSitemap}},name='django.contrib.sitemaps.views.sitemap'),
+    url(r'^sitemap\.xml$',
+        sitemap,
+        {'sitemaps': {'event': EventSitemap, 'page': CMSSitemap}},
+        name='django.contrib.sitemaps.views.sitemap'),
+
     # For better authentication
     url(r'^accounts/', include('allauth.urls')),
 


### PR DESCRIPTION
This pull request adds a setup.cfg file to handle pycodestyle for PEP8 linting: https://github.com/PyCQA/pycodestyle with a line length limit of 120.

In addition, it also lints default_settings.py and urls.py