### PR TITLE
Fix rich textbox edit fields

### DIFF
--- a/danceschool/default_settings.py
+++ b/danceschool/default_settings.py
@@ -85,7 +85,7 @@ CKEDITOR_SETTINGS = {
         {'name': 'insert', 'items': ['FilerImage', 'Table', 'HorizontalRule', 'Smiley', 'Iframe']},
         {'name': 'tools', 'items': ['Maximize', 'ShowBlocks', 'Source']},
     ],
-    'skin': 'moono',
+    'skin': 'moono-lisa',
     'extraPlugins': ','.join(
         [
             # you extra plugins here


### PR DESCRIPTION
Certain textboxes, like the Location Directions or Dance Series Description, were not appearing using the default styling configuration. The requests for the css and js were 404'ing. This is because the default settings for ckeditor referred to the skin 'moono' which is not included in the static files. The skin that is included is called 'moono-lisa'.