### PR TITLE
Simplify README text

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,79 +4,26 @@ Welcome to the Django Dance School project
 Who is this project for?
 ------------------------
 
-Partnered social dance schools are complicated. We run regular class
-series in all sorts of different configurations, which may require
-prerequisites, auditions, complex pricing, etc. We also often run public
-events, some of which require registration, and some of which do not. We
-often manage numerous instructors, teach in numerous locations, and have
-to manage schedules and finances for all of these things.
+Partnered social dance schools are complicated. They involve regular classes in multiple configurations which can have prerequisites, auditions, complex pricing, etc. There may also be public events which require registration, and often involve managing instructors, venues, scheduling and finances.
 
-At the same time, partnered social dance schools are often run by
-amateurs, with limited time and resources. The founders of this project
-are all Lindy Hoppers, and in that community, even many of the most
-prominent and successful dance schools have zero full-time staff. We
-have seen many instances of schools that are simply unable to grow or
-expand their reach, because they lack the time and resources to manage
-all of the logistical details. Those constraints are a disservice to the
-dance.
+These dance schools are often run by people with limited time and resources. The founders of this project are all Lindy Hoppers, and in this community, even the most prominent and successful dance schools have zero full-time staff. Many schools are unable to grow because they lack the time and resources to manage all of the logistics, whose constraints are a disservice to the dance.
 
-Over a period of several years, in Boston, we have sought to address
-these issues by building our own custom registration system, complete
-with all of the features needed to run a sophisticated dance school.
-Surprisingly, the commercial options for dance schools are very limited,
-inflexible, and often expensive. We ended up with software that suits
-our needs well, but that is also adaptable enough to be suited to a wide
-range of dance schools, including partnered social dances of all types,
-but also to many other types of dance. This project is the result of
-those efforts.
+Over several years, `Boston Lindy Hop <https://bostonlindyhop.com/>`__ has sought to address these issues by building a custom registration system with all of the features needed to run a dance school. The commercial options for dance schools are often limited, inflexible, and expensive. This sofware is adaptable enough to be suited to a wide range of dance schools, partnered or otherwise.
 
-The project is designed to be very modular and adaptable to the needs to
-individual dance schools. You can readily customize the behavior of your
-site to meet your needs, all while maintaining full integration between
-your registration system and the public facing portions of the site.
-Many features that are not needed can be turned off without affecting
-the rest of the site, and the entire system is built with an eye toward
-making it easy for individual schools to add custom functionality and
-behavior.
+The project is designed to be modular and adaptable to the needs to individual dance schools, and can be readily customized while maintaining full integration between the registration system and the public facing parts of the website. Unnecessary features can be turned off, and the entire system is built with a focus on simple usage and customization.
 
-The whole thing is integrated with a popular content management system
-called `Django CMS <https://www.django-cms.org/en/>`__, that works
-similar to other CMS systems that you may be familiar with. That means
-that day-to-day tasks like editing website content are easy; once your
-site is up and running, it is in most respects as easy to edit and
-maintain content as a site built on any other content management
-software. Best of all, this software is free and open source, so you are
-not stuck paying hefty service fees to a third-party registration
-provider for as long as your studio is in operation.
-
-The cost of this flexibility is that getting your site up and running
-will take a little bit more work than it would with a paid service. You
-will need to run your own copy of this software on a hosted webserver.
-You will also need to manually enter a few key site settings before your
-site is ready for use, such as email, database, and payment credentials.
-Finally, you will probably wish, at a minimum, to create or adopt a
-custom template for your site's design, and to integrate those into this
-project's content management system (see details below). If you are
-unfamiliar with web hosting using Python and Django, then it may be a
-good idea to consult a person with the relevant expertise to get your
-dance school's website up and running. However, we think that once you
-have things running, you will find that the benefits of having your own
-system are considerable.
+Django Dance School is integrated with `Django CMS <https://www.django-cms.org/en/>`__, which works similarly to other content management systems, making tasks like editing website content easy. Once the website is up and running, it is as straightforward to edit and maintain content as any other CMS. Best of all, this software is free and open source, so you are not stuck paying hefty service fees to a third-party registration provider.
 
 Overview of Features
 --------------------
 
 The following are the main features of the project:
 
--  Class registration (advance online registration and at-the-door
-   registration with separate pricing for each)
--  Emailing of registered students
--  Paypal Express Checkout integration for registration and refunds
--  Stripe Checkout integration for registration and refunds
--  Instructor scheduling
--  Internal scheduling (private internal calendars for all staff
-   members)
--  Substitute teaching
+-  Class registration (Including conditional pricing)
+-  Emailmanagement
+-  Paypal and Stripe integration for registration and refunds
+-  Instructor scheduling (Including substitutions)
+-  Internal scheduling (Private calendars for staff members)
 -  Expense and revenue reporting
 -  Optional automatic generation of expense and revenue line items for
    instructors, substitute teachers, and venues


### PR DESCRIPTION
I think a lot of the README text was quite overly verbose and had a lot
of redundant information and unnecessary qualifiers. The tone and
perspective also changed quite a lot.

I pretty much stripped down everything I could and tried to re-phrase
everything where it made sense. I think the README itself could still go
with a lot more work, but I will propose it as part of a larger set of
changes alongside a pull request.