### PR TITLE
Fix html5lib version mismatch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ django-colorful>=1.2
 django-crispy-forms>=1.6.0
 django-daterange-filter>=1.2.0
 django-dynamic-preferences>=1.4.2
-django-easy-pdf>=0.1.0
+django-easy-pdf==0.1.0
 django-filer>=1.2.7
 django-ical>=1.4
 django-imagekit>=3.3
@@ -38,3 +38,4 @@ six>=1.10.0
 squareconnect>=2.2.1
 stripe>=1.62.0
 unicodecsv>=0.14.1
+xhtml2pdf==0.1b1

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
         'django-crispy-forms>=1.6.0',
         'django-daterange-filter>=1.2.0',
         'django-dynamic-preferences>=1.4.2',
-        'django-easy-pdf>=0.1.0',
+        'django-easy-pdf==0.1.0',
         'django-filer>=1.2.7',
         'django-ical>=1.4',
         'django-imagekit>=3.3',
@@ -61,6 +61,7 @@ setup(
         'squareconnect>=2.2.1',
         'stripe>=1.62.0',
         'unicodecsv>=0.14.1',
+        'xhtml2pdf==0.1b1',
     ],
     classifiers=[
         'Environment :: Web Environment',


### PR DESCRIPTION
Both django-easy-pdf and djangocms-text-ckeditor have html5lib as one of their subdependencies. Setting django-easy-pdf's version in the requirements to >=0.1.0 causes the package to resolve to version 0.1.1, and its subdependency xhtml2lib to version html5lib>=1.0b10, causing a mismatch with djangocms-text-ckeditor required version, html5lib>=0.999999.

The solution is to pin django-easy-pdf to version 0.1.0, which also requires explicitly adding xhtml2pdf=0.1b1 to the requirements (see https://github.com/nigma/django-easy-pdf/tree/0.1.0#quickstart, xhtml2pdf 0.1b1 is the latest compatible with the html5lib required by djangocms-text-ckeditor).

There's currently a pull request in djangocms-text-ckeditor to update its use of html5lib (see https://github.com/divio/djangocms-text-ckeditor/issues/403), but it has yet to be merged. Once it is updated, django-easy-pdf can be updated and the explicit xhtml2lib dependency can be removed.