### PR TITLE
Fix broken development documention link in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,7 +80,7 @@ the Django development server, then this method of installation is for you.
 
 For more detailed instructions, and for a discussion of possible issues that
 may arise, see the `Documentation
-<https://django-danceschool.readthedocs.io/en/latest/installation.html#development-installation>`__.
+<https://django-danceschool.readthedocs.io/en/latest/installation_development.html>`__.
 
 What you will need:
 ===================


### PR DESCRIPTION
This pull request addresses #106 by editing README.rst to fix the broken link to the [development documentation](https://django-danceschool.readthedocs.io/en/latest/installation_development.html).