### PR TITLE
Removing reversed from base_individual_class.html

### DIFF
--- a/danceschool/core/templates/core/base/base_individual_class.html
+++ b/danceschool/core/templates/core/base/base_individual_class.html
@@ -82,7 +82,7 @@
 
 			<p class='schedule'>
 			<strong>{% trans "Class Schedule" %}:</strong><br />
-			{% for class in series.eventoccurrence_set.all reversed %}
+			{% for class in series.eventoccurrence_set.all %}
 				{{ class.startTime|date:'F j, h:i' }}&nbsp;-&nbsp;{{ class.endTime|date:'h:i A' }}<br />
 			{% endfor %}
 			</p>

--- a/danceschool/core/templates/core/base/base_individual_class.html
+++ b/danceschool/core/templates/core/base/base_individual_class.html
@@ -40,7 +40,7 @@
 			<div class="row mb-4">
 			{% for teacher in series.teachers %}
 				{% if teacher.image %}
-					<img src="{% thumbnail teacher.image 118x118 crop %}" title="{{teacher.firstName}} {{teacher.lastName}}" alt="{{teacher.firstName}} {{teacher.lastName}}" width="118px" class="float-right" style="margin: 5px;" />
+					<img src="{% thumbnail teacher.image 118x118 crop %}" title="{{teacher.firstName}} {{teacher.lastName}}" alt="{{teacher.firstName}} {{teacher.lastName}}" width="118px" class="float-right" style="margin: 5px;" /> 
 				{% endif %}
 			{% endfor %}
 			</div>
@@ -73,7 +73,7 @@
 			</h4>
 
 			{% if series.teachers %}
-				<h4 class="instructor-names">{% trans "with" %}
+				<h4 class="instructor-names">{% trans "with" %} 
 				{% for teacher in series.teachers %}
 						{{ teacher.firstName }} {{ teacher.lastName }}{% if not forloop.last %} {% trans "and" %} {% endif %}
 				{% endfor %}
@@ -101,7 +101,7 @@
 			</p>
 			{% endif %}
 		</div>
-	</div>
+	</div>	
 
 	<hr />
 
@@ -119,9 +119,9 @@
 	{% addtoblock "js" %}
 		<script type="text/javascript">
 		$( document ).ready(function() {
-			$('.pricingPopover').popover();
+			$('.pricingPopover').popover();	
 		});
 		</script>
 	{% endaddtoblock %}
-
+	
 {% endblock %}

--- a/danceschool/core/templates/core/base/base_individual_class.html
+++ b/danceschool/core/templates/core/base/base_individual_class.html
@@ -40,7 +40,7 @@
 			<div class="row mb-4">
 			{% for teacher in series.teachers %}
 				{% if teacher.image %}
-					<img src="{% thumbnail teacher.image 118x118 crop %}" title="{{teacher.firstName}} {{teacher.lastName}}" alt="{{teacher.firstName}} {{teacher.lastName}}" width="118px" class="float-right" style="margin: 5px;" /> 
+					<img src="{% thumbnail teacher.image 118x118 crop %}" title="{{teacher.firstName}} {{teacher.lastName}}" alt="{{teacher.firstName}} {{teacher.lastName}}" width="118px" class="float-right" style="margin: 5px;" />
 				{% endif %}
 			{% endfor %}
 			</div>
@@ -73,7 +73,7 @@
 			</h4>
 
 			{% if series.teachers %}
-				<h4 class="instructor-names">{% trans "with" %} 
+				<h4 class="instructor-names">{% trans "with" %}
 				{% for teacher in series.teachers %}
 						{{ teacher.firstName }} {{ teacher.lastName }}{% if not forloop.last %} {% trans "and" %} {% endif %}
 				{% endfor %}
@@ -101,7 +101,7 @@
 			</p>
 			{% endif %}
 		</div>
-	</div>	
+	</div>
 
 	<hr />
 
@@ -119,9 +119,9 @@
 	{% addtoblock "js" %}
 		<script type="text/javascript">
 		$( document ).ready(function() {
-			$('.pricingPopover').popover();	
+			$('.pricingPopover').popover();
 		});
 		</script>
 	{% endaddtoblock %}
-	
+
 {% endblock %}


### PR DESCRIPTION
Currently classes are being shown in the reverse chronological order [as shown here on Cat's Corner's Website](https://registration.catscorner.ca/classes/2019/February/swing-2/). 

Boston Lindy Hop, had the same previous issue until we overwrote the template in our custom repo. This pull request is to fix the issue in Django Dance School.