### PR TITLE
Handle PEP8 errors for vouchers/views.py

### DIFF
--- a/danceschool/vouchers/views.py
+++ b/danceschool/vouchers/views.py
@@ -66,7 +66,7 @@ class GiftCertificateCustomizeView(FormView):
             currency_symbol = getConstant('general__currencySymbol')
             voucher = Voucher.create_new_code(
                 prefix='GC_',
-                name=_('Gift certificate: %s%s for %s' % (currency_symbol, self.amount, emailTo)),
+                name=_('Gift certificate: {currency_symbol}{amount} for {email_recipient}').format(x=y, etc),
                 category=getConstant('vouchers__giftCertCategory'),
                 originalAmount=self.amount,
                 singleUse=False,

--- a/danceschool/vouchers/views.py
+++ b/danceschool/vouchers/views.py
@@ -28,15 +28,15 @@ class GiftCertificateCustomizeView(FormView):
     template_name = 'cms/forms/display_form_classbased.html'
     form_class = VoucherCustomizationForm
 
-    def dispatch(self,request,*args,**kwargs):
+    def dispatch(self, request, *args, **kwargs):
         '''
         Check that a valid Invoice ID has been passed in session data,
         and that said invoice is marked as paid.
         '''
         paymentSession = request.session.get(INVOICE_VALIDATION_STR, {})
         self.invoiceID = paymentSession.get('invoiceID')
-        self.amount = paymentSession.get('amount',0)
-        self.success_url = paymentSession.get('success_url',reverse('registration'))
+        self.amount = paymentSession.get('amount', 0)
+        self.success_url = paymentSession.get('success_url', reverse('registration'))
 
         # Check that Invoice matching passed ID exists
         try:
@@ -47,9 +47,9 @@ class GiftCertificateCustomizeView(FormView):
         if i.unpaid or i.amountPaid != self.amount:
             return HttpResponseBadRequest(_('Passed invoice is not paid.'))
 
-        return super(GiftCertificateCustomizeView,self).dispatch(request,*args,**kwargs)
+        return super(GiftCertificateCustomizeView, self).dispatch(request, *args, **kwargs)
 
-    def form_valid(self,form):
+    def form_valid(self, form):
         '''
         Create the gift certificate voucher with the indicated information and send
         the email as directed.
@@ -63,9 +63,10 @@ class GiftCertificateCustomizeView(FormView):
         logger.info('Processing gift certificate.')
 
         try:
+            currency_symbol = getConstant('general__currencySymbol')
             voucher = Voucher.create_new_code(
                 prefix='GC_',
-                name=_('Gift certificate: %s%s for %s' % (getConstant('general__currencySymbol'),self.amount, emailTo)),
+                name=_('Gift certificate: %s%s for %s' % (currency_symbol, self.amount, emailTo)),
                 category=getConstant('vouchers__giftCertCategory'),
                 originalAmount=self.amount,
                 singleUse=False,
@@ -94,7 +95,7 @@ class GiftCertificateCustomizeView(FormView):
         if recipientName:
             pdf_kwargs.update({})
 
-        attachment = GiftCertificatePDFView(request=pdf_request).get(request=pdf_request,**pdf_kwargs).content or None
+        attachment = GiftCertificatePDFView(request=pdf_request).get(request=pdf_request, **pdf_kwargs).content or None
 
         if attachment:
             attachment_name = 'gift_certificate.pdf'
@@ -126,7 +127,7 @@ class GiftCertificateCustomizeView(FormView):
         )
 
         # Remove the invoice session data
-        self.request.session.pop(INVOICE_VALIDATION_STR,None)
+        self.request.session.pop(INVOICE_VALIDATION_STR, None)
 
         return HttpResponseRedirect(self.get_success_url())
 
@@ -134,14 +135,14 @@ class GiftCertificateCustomizeView(FormView):
 class GiftCertificatePDFView(PDFTemplateView):
     template_name = 'vouchers/pdf/giftcertificate_template.html'
 
-    def get_context_data(self,**kwargs):
-        context = super(GiftCertificatePDFView,self).get_context_data(**kwargs)
+    def get_context_data(self, **kwargs):
+        context = super(GiftCertificatePDFView, self).get_context_data(**kwargs)
 
         template = getConstant('vouchers__giftCertPDFTemplate')
 
         # For security reasons, the following tags are removed from the template before parsing:
         # {% extends %}{% load %}{% debug %}{% include %}{% ssi %}
-        content = re.sub('\{%\s*((extends)|(load)|(debug)|(include)|(ssi))\s+.*?\s*%\}','',template.content)
+        content = re.sub(r'\{%\s*((extends)|(load)|(debug)|(include)|(ssi))\s+.*?\s*%\}', '', template.content)
 
         t = Template(content)
 


### PR DESCRIPTION
Previously running pycodestyle (PEP8 linter) on `vouchers/views.py` came up with W605, E231, and E501 PEP8 errors. This pull request has code changes to address them and issue #131.

Note: The reviewer should check voucher creation still works correctly with these changes.