### PR TITLE
Handle PEP8 errors for vouchers/cms_toolbars.py

### DIFF
--- a/danceschool/vouchers/cms_toolbars.py
+++ b/danceschool/vouchers/cms_toolbars.py
@@ -11,7 +11,16 @@ class VoucherLinksToolbar(CMSToolbar):
     ''' Add vouchers to the financial menu '''
 
     def populate(self):
-        if not (self.request.user.has_perm('vouchers.change_voucher') or self.request.user.has_perm('vouchers.change_vouchercategory')):
+        # Voucher permission booleans
+        permission_change_voucher = self.request.user.has_perm(
+            'vouchers.change_voucher'
+        )
+        permission_change_voucher_category = self.request.user.has_perm(
+            'vouchers.change_vouchercategory'
+        )
+
+        if not (permission_change_voucher or permission_change_voucher_category):
+            # TODO: Handle lack of permissions better
             return
 
         financial_menu = self.toolbar.get_or_create_menu(
@@ -29,9 +38,19 @@ class VoucherLinksToolbar(CMSToolbar):
                 identifier='financial_related_items_break'
             ) + 1
 
-        related_menu = financial_menu.get_or_create_menu('financial-related',_('Related Items'), position=position)
+        related_menu = financial_menu.get_or_create_menu(
+            'financial-related',
+            _('Related Items'),
+            position=position
+        )
 
-        if self.request.user.has_perm('vouchers.change_vouchercategory'):
-            related_menu.add_link_item(_('Voucher Categories'), url=reverse('admin:vouchers_vouchercategory_changelist'))
-        if self.request.user.has_perm('vouchers.change_voucher'):
-            related_menu.add_link_item(_('Vouchers'), url=reverse('admin:vouchers_voucher_changelist'))
+        if permission_change_voucher_category:
+            related_menu.add_link_item(
+                _('Voucher Categories'),
+                url=reverse('admin:vouchers_vouchercategory_changelist')
+            )
+        if permission_change_voucher_category:
+            related_menu.add_link_item(
+                _('Vouchers'),
+                url=reverse('admin:vouchers_voucher_changelist')
+            )


### PR DESCRIPTION
Previously running pycodestyle (PEP8 linter) on vouchers/helpers.py came up with E231, W291, and E501 PEP8 errors. This pull request has code changes to address them and issue #131.

Notes: 

- The reviewer should check voucher creation still works correctly with these changes
- The line limit was set at 100 for the checks with pycodestyle. We are still in discussion of max-line-length for the project but it will at minimum likely be 100.