### PR TITLE
Fix syntax error in PayPal and Stripe setup commands

### DIFF
--- a/danceschool/payments/paypal/management/commands/setup_paypal.py
+++ b/danceschool/payments/paypal/management/commands/setup_paypal.py
@@ -106,7 +106,7 @@ CHECKING PAYPAL INTEGRATION
                     ('registration_payatdoor_placeholder', 'at-the-door payments')
                 ]
 
-                for p in in placeholders:
+                for p in placeholders:
                     paynow_sp = StaticPlaceholder.objects.get_or_create(code=p[0])
                     paynow_p_draft = paynow_sp[0].draft
                     paynow_p_public = paynow_sp[0].public

--- a/danceschool/payments/stripe/management/commands/setup_stripe.py
+++ b/danceschool/payments/stripe/management/commands/setup_stripe.py
@@ -101,7 +101,7 @@ CHECKING STRIPE INTEGRATION
                     ('registration_payatdoor_placeholder', 'at-the-door payments')
                 ]
 
-                for p in in placeholders:
+                for p in placeholders:
                     stripe_sp = StaticPlaceholder.objects.get_or_create(code=p[0])
                     stripe_p_draft = stripe_sp[0].draft
                     stripe_p_public = stripe_sp[0].public


### PR DESCRIPTION
There's a duplicate `in` in both scripts.