### PR TITLE
Allocate per-event cart discounts to specific InvoiceItems

### DIFF
--- a/danceschool/core/views/registration.py
+++ b/danceschool/core/views/registration.py
@@ -244,15 +244,74 @@ class RegistrationSummaryView(
             combined_response['total_posttax'] += response[1].get('total_posttax', 0)
             combined_response['items'] += response[1].get('items', [])
 
-        # The updateTotals method allocates the total adjustment across the
-        # invoice items, and also recalculates the taxes for each item.
-        invoice.updateTotals(
-            allocateAmounts={
-                'total': -1*(combined_response['total_pretax'] + total_discount_amount),
-                'adjustments': -1*(combined_response['total_posttax']),
-            },
-            save=True,
-        )
+        # The updateTotals method allocates adjustments across invoice items
+        # and recalculates per-item taxes. Without per-item weights the
+        # default behavior is to allocate every change proportionally to
+        # grossTotal, which is wrong when a discount only covers a subset
+        # of items (e.g. a 100%-off code on one event in a mixed cart):
+        # the discount would bleed onto unrelated items and leave both
+        # per-item totals and per-event-tax-rate grand totals incorrect.
+        #
+        # Build weights from the last DiscountInfo's per-event allocation
+        # so the discount portion lands only on the items it actually
+        # covered. Vouchers and post-tax adjustments stay proportional in
+        # a chained second call (allocateWeights cannot be mixed across
+        # pre-tax and post-tax buckets in a single updateTotals call).
+        discount_weights = {}
+        if reg and discount_codes:
+            final = discount_codes[-1]
+            event_ids = list(getattr(final, 'net_allocated_event_ids', []) or [])
+            allocated = list(final.net_allocated_prices or [])
+            if event_ids and len(event_ids) == len(allocated):
+                # net_allocated_event_ids only contains events that were
+                # in the discount-eligibility list (non-drop-in, with a
+                # pricing tier), so we only need to map those here.
+                # Note: if a cart contains multiple non-drop-in
+                # registrations for the SAME event (multi-customer
+                # case), only one InvoiceItem ends up in this map; the
+                # remaining items fall back to proportional allocation
+                # for the unaccounted share. This is a corner case.
+                er_qs = reg.eventregistration_set.select_related(
+                    'invoiceItem', 'event'
+                ).filter(dropIn=False)
+                items_by_event = {
+                    er.event.id: er.invoiceItem for er in er_qs
+                    if er.invoiceItem is not None
+                }
+                for ev_id, net in zip(event_ids, allocated):
+                    item = items_by_event.get(ev_id)
+                    if item is None:
+                        continue
+                    weight = float(item.grossTotal) - float(net)
+                    if weight > 0:
+                        discount_weights[str(item.id)] = weight
+
+        pretax_total = -1*(combined_response['total_pretax'] + total_discount_amount)
+        posttax_total = -1*(combined_response['total_posttax'])
+
+        if discount_weights:
+            # Apply the discount (and any pre-tax vouchers) with per-item
+            # weights, then if there are post-tax adjustments apply those
+            # separately so updateTotals' "weights forbid mixing pre-tax
+            # and post-tax buckets" constraint is respected.
+            invoice.updateTotals(
+                save=True,
+                allocateAmounts={'total': pretax_total},
+                allocateWeights=discount_weights,
+            )
+            if posttax_total != 0:
+                invoice.updateTotals(
+                    save=True,
+                    allocateAmounts={'adjustments': posttax_total},
+                )
+        else:
+            invoice.updateTotals(
+                allocateAmounts={
+                    'total': pretax_total,
+                    'adjustments': posttax_total,
+                },
+                save=True,
+            )
 
         # Update the session key to keep track of this registration
         regSession = request.session[REG_VALIDATION_STR]

--- a/danceschool/discounts/models.py
+++ b/danceschool/discounts/models.py
@@ -107,9 +107,13 @@ class DiscountCombo(models.Model):
 
     # Net allocated prices are optional, everything else is required.
     DiscountInfo = namedtuple(
-        'DiscountInfo', ['code', 'net_price', 'discount_amount', 'net_allocated_prices']
+        'DiscountInfo',
+        [
+            'code', 'net_price', 'discount_amount',
+            'net_allocated_prices', 'net_allocated_event_ids',
+        ]
     )
-    DiscountInfo.__new__.__defaults__ = ([], )
+    DiscountInfo.__new__.__defaults__ = ([], [])
 
     # A DiscountApplication contains a list of DiscountInfo tuples to be applied, along with an optional
     # total for ineligible items to be added to the discounted net price at the end.
@@ -308,7 +312,14 @@ class DiscountCombo(models.Model):
         if this_price < initial_net_price:
             # Ensure no negative prices
             this_price = max(this_price, 0)
-            return self.DiscountInfo(self, this_price, initial_net_price - this_price, this_allocated_prices)
+            # Capture per-position event identity so downstream code can map
+            # net_allocated_prices back to specific InvoiceItems without
+            # depending on the (unordered) queryset position in helpers.
+            event_ids = [t[0].get('event_id') for t in tieredTuples]
+            return self.DiscountInfo(
+                self, this_price, initial_net_price - this_price,
+                this_allocated_prices, event_ids,
+            )
 
     @property
     def hasExpired(self):

--- a/danceschool/discounts/tests.py
+++ b/danceschool/discounts/tests.py
@@ -8,7 +8,7 @@ from datetime import timedelta
 
 from danceschool.core.constants import REG_VALIDATION_STR, updateConstant
 from danceschool.core.tests.defaults import DefaultSchoolTestCase
-from danceschool.core.models import Invoice, Registration
+from danceschool.core.models import Invoice, PricingTier, Registration
 
 from .models import (
     PointGroup, PricingTierGroup, DiscountCategory, DiscountCombo, DiscountComboComponent
@@ -761,3 +761,146 @@ class CartSummaryDiscountPreviewTest(BaseDiscountsTest):
         preview = response.context_data.get('discount_preview')
         self.assertIsNotNone(preview)
         self.assertGreater(preview['total_discount'], 0)
+
+
+class MixedCartDiscountAllocationTest(BaseDiscountsTest):
+    '''
+    Reproduces a bug where a discount that applies to only some items in a
+    mixed cart is allocated proportionally across ALL items by grossTotal,
+    rather than being attributed to the items the discount actually covered.
+
+    Scenario: cart contains a $10 regular series + a $20 series eligible for
+    a 100% discount. Expected per-item totals after discount: $10 and $0.
+    Buggy current behavior allocates the $20 discount as $6.67 off the $10
+    item and $13.33 off the $20 item, leaving misleading per-item totals
+    (and a wrong grand total once items have different tax rates).
+    '''
+
+    def _make_tier(self, name, price):
+        return PricingTier.objects.create(
+            name=name, onlinePrice=price, doorPrice=price, dropinPrice=price,
+        )
+
+    def _make_full_off_combo(self, point_group, name):
+        # Uses percentDiscount (non-universal) so the discount attributes
+        # to specifically-covered items rather than spreading across the
+        # whole cart. flatPrice and dollarDiscount currently spread
+        # proportionally (see DiscountCombo.applyAndAllocate); that's a
+        # separate concern from this test.
+        combo = DiscountCombo.objects.create(
+            name=name,
+            category=DiscountCategory.objects.get(id=1),
+            discountType=DiscountCombo.DiscountType.percentDiscount,
+            percentDiscount=100,
+            percentUniversallyApplied=False,
+            active=True,
+            availableOnline=True,
+            availableAtDoor=True,
+        )
+        DiscountComboComponent.objects.create(
+            discountCombo=combo, pointGroup=point_group, quantity=5,
+            allWithinPointGroup=False,
+        )
+        return combo
+
+    def test_full_discount_on_one_item_does_not_affect_other_items(self):
+        updateConstant('general__discountsEnabled', True)
+
+        tier_a = self._make_tier('Cheap Tier', 10)
+        tier_b = self._make_tier('Pricey Tier', 20)
+
+        # Series A is ineligible for the discount; series B is the only
+        # member of the point group the discount requires.
+        s_a = self.create_series(pricingTier=tier_a)
+        s_b = self.create_series(pricingTier=tier_b)
+
+        b_only_group = PointGroup.objects.create(name='Tier B only')
+        PricingTierGroup.objects.create(
+            group=b_only_group, pricingTier=tier_b, points=5,
+        )
+        self._make_full_off_combo(b_only_group, 'Free Tier B')
+
+        cart_data = {
+            'items': [
+                {
+                    'item_type': 'Event', 'item_id': s_a.id,
+                    'sku': f'EVENT_{s_a.id}_GENERAL', 'quantity': 1,
+                },
+                {
+                    'item_type': 'Event', 'item_id': s_b.id,
+                    'sku': f'EVENT_{s_b.id}_GENERAL', 'quantity': 1,
+                },
+            ],
+            'checkout': True,
+        }
+        response = self.client.post(
+            reverse('cart'),
+            data=json.dumps(cart_data),
+            content_type='application/json',
+        )
+        self.assertEqual(response.status_code, 302)
+
+        response = self.client.post(reverse('getStudentInfo'), {
+            'firstName': 'Mixed',
+            'lastName': 'Cart',
+            'email': 'mixed@cart.com',
+            'agreeToPolicies': True,
+        }, follow=True)
+        # Two items in the cart → flow detours through the multi-customer
+        # name form before reaching the summary page.
+        self.assertEqual(
+            response.redirect_chain, [(reverse('multiRegNameInfo'), 302)],
+        )
+
+        invoice_pre = Invoice.objects.get(
+            id=self.client.session[REG_VALIDATION_STR].get('invoice_id')
+        )
+        reg_pre = Registration.objects.get(invoice=invoice_pre)
+        name_post = {}
+        for er in reg_pre.eventregistration_set.all():
+            name_post['er_%s_firstName' % er.id] = 'Mixed'
+            name_post['er_%s_lastName' % er.id] = 'Cart'
+            name_post['er_%s_email' % er.id] = 'mixed@cart.com'
+
+        response = self.client.post(
+            reverse('multiRegNameInfo'), name_post, follow=True,
+        )
+        self.assertEqual(
+            response.redirect_chain, [(reverse('showRegSummary'), 302)],
+        )
+
+        invoice = response.context_data.get('invoice')
+        items = {it.grossTotal: it for it in invoice.invoiceitem_set.all()}
+
+        # Sanity: the right items exist with the right gross totals.
+        self.assertIn(10, items, 'Series A item with grossTotal $10 missing')
+        self.assertIn(20, items, 'Series B item with grossTotal $20 missing')
+        item_a = items[10]
+        item_b = items[20]
+
+        # Invoice grand total must be $10 (the regular item) regardless.
+        # Use assertAlmostEqual for floating-point money math.
+        self.assertAlmostEqual(
+            invoice.total, 10, places=2,
+            msg='Invoice total wrong after applying $20 discount to a $20 item',
+        )
+        self.assertEqual(
+            response.context_data.get('total_discount_amount'), 20,
+        )
+
+        # The discount applied only to item B, so item A must keep its
+        # full $10 total and item B must be reduced to $0.
+        self.assertAlmostEqual(
+            item_a.total, 10, places=2,
+            msg=(
+                'Item A (regular $10) should not be discounted; '
+                'got {0} (suggests proportional allocation bug)'
+            ).format(item_a.total),
+        )
+        self.assertAlmostEqual(
+            item_b.total, 0, places=2,
+            msg=(
+                'Item B (eligible for 100% off) should be $0; '
+                'got {0} (suggests proportional allocation bug)'
+            ).format(item_b.total),
+        )


### PR DESCRIPTION
## Summary

Fixes a cart-math bug where a discount targeting one event in a mixed cart is allocated proportionally across all items by grossTotal instead of landing on the items the discount actually covers.

**Reproducer scenario** (covered by the new test):

| Cart | Expected per-item totals | Current behavior |
|---|---|---|
| $10 regular + $20 with 100% off | $10 and **$0** | $3.33 and $6.67 |

The invoice grand total still happens to equal $10 in the symmetric tax-rate case (errors cancel), but per-item totals on the summary page are visibly wrong, and the grand total *also* lands wrong when items have differing tax rates (e.g. a Series + a PublicEvent in the same cart, with `seriesSalesTaxRate` ≠ `publicEventSalesTaxRate`).

## Root cause

`RegistrationSummaryView.get` (`core/views/registration.py:249-255`) calls `invoice.updateTotals(allocateAmounts={'total': -discount_amount, ...})` without `allocateWeights`. `DiscountInfo.net_allocated_prices` — which already knows which items the discount covers — is dropped by the `apply_discount` signal, so `updateTotals` falls back to proportional allocation by grossTotal.

## Fix

1. **`discounts/models.py`**: extend `DiscountInfo` with `net_allocated_event_ids` parallel to `net_allocated_prices`. `applyAndAllocate` captures the `event_id` from each `tieredTuple` so downstream code can map per-position allocations back to specific `InvoiceItem`s without depending on queryset position in `prepareCartObjects` (which has no `order_by` and is not stable across DB backends).

2. **`core/views/registration.py`**: build `allocateWeights` from the last `DiscountInfo`'s per-event allocation (weight = `grossTotal − net_allocated_price`), then split the single `updateTotals` call into two — pre-tax discount with weights, then post-tax adjustments without — because `updateTotals` forbids mixing pre-tax and post-tax buckets when `allocateWeights` is in play.

## Scope notes

- **Only fixes the `percentDiscount` (non-universal) path.** The `flatPrice` and `dollarDiscount` branches of `applyAndAllocate` currently spread the discount proportionally across all items in `net_allocated_prices`, even items the discount doesn't cover. The comment at `models.py:275` (*"Flat prices are allocated equally across all events"*) reads as intentional design, so I held back from changing it — happy to follow up if that read is wrong.
- For multi-customer carts where two non-drop-in `EventRegistration`s reference the *same* event, only one `InvoiceItem` ends up in the event-id-keyed map; the remainder falls back to proportional allocation. Inline comment in the code; unlikely in practice.

## Verification

- Failing test added in the first commit (`MixedCartDiscountAllocationTest.test_full_discount_on_one_item_does_not_affect_other_items`) reproduces the bug.
- The fix in the second commit makes that test pass.
- Full `danceschool.discounts` + `danceschool.vouchers` suites pass (59 tests, no regressions).
- Three pre-existing failures in `danceschool.core.tests` (LinkOnly URL handling, dynamic_preferences serialization) reproduce on `0.9.0-dev` without this patch and are unrelated.

## Test plan
- [ ] Review the per-event allocation logic in `RegistrationSummaryView.get`
- [ ] Confirm the scope decision on flatPrice/dollarDiscount paths (intentional vs. bug)
- [ ] Pull and run `python manage.py test danceschool.discounts danceschool.vouchers`