### PR TITLE
Test: back-button reset wipes prior non-discount adjustments

### DIFF
--- a/danceschool/core/tests/test_cart.py
+++ b/danceschool/core/tests/test_cart.py
@@ -1,8 +1,9 @@
 import json
+import unittest
 
 from django.urls import reverse
 
-from ..models import Registration, Invoice, EventRole
+from ..models import Registration, Invoice, InvoiceItem, EventRole
 from ..constants import updateConstant, REG_VALIDATION_STR
 from .defaults import DefaultSchoolTestCase
 
@@ -543,3 +544,47 @@ class CartSummaryViewTest(DefaultSchoolTestCase):
         items = self.client.session[REG_VALIDATION_STR]['cart']['items']
         self.assertEqual(len(items), 1)
         self.assertEqual(items[0]['sku'], f'EVENT_{series.id}_GENERAL')
+
+
+class BackButtonAdjustmentsResetTest(DefaultSchoolTestCase):
+    '''
+    Reproduces a bug in Invoice.updateTotals where the back-button reset
+    path (invoices.py:416-432) restores each item's `adjustments` from
+    `data._initial_adjustments`, defaulting to 0 when that key is absent.
+    The key is never captured anywhere on the original pass, so any
+    pre-existing non-discount adjustment is silently wiped to 0 on retry.
+    '''
+
+    @unittest.expectedFailure
+    def test_back_button_preserves_prior_non_discount_adjustments(self):
+        series = self.create_series(pricingTier=self.defaultPricing)
+        invoice = Invoice.objects.create(
+            firstName='Back', lastName='Button', email='back@test.com',
+            grossTotal=series.getBasePrice(),
+            total=series.getBasePrice(),
+            status=Invoice.PaymentStatus.preliminary,
+        )
+        item = InvoiceItem.objects.create(
+            invoice=invoice,
+            grossTotal=series.getBasePrice(),
+            total=series.getBasePrice(),
+            adjustments=-3,
+            data={'_initial_total': series.getBasePrice()},
+        )
+        invoice.adjustments = -3
+        invoice.data['saved_adjustments'] = True
+        invoice.save()
+
+        # Simulate the back-button retry path: updateTotals runs again on
+        # the still-preliminary invoice, sees saved_adjustments=True, and
+        # resets per-item totals/adjustments before re-applying anything.
+        invoice.updateTotals(save=True)
+
+        item.refresh_from_db()
+        self.assertEqual(
+            item.adjustments, -3,
+            msg=(
+                'Prior non-discount adjustment of -3 was wiped to {0} '
+                'because _initial_adjustments was never captured.'
+            ).format(item.adjustments),
+        )


### PR DESCRIPTION
## Summary

Adds a regression test reproducing a bug in `Invoice.updateTotals`. The back-button reset block (`core/models/invoices.py:416-432`) restores each item's `adjustments` from `data._initial_adjustments`, defaulting to 0 when that key is absent. The key is never captured anywhere on the original pass, so any pre-existing non-discount adjustment (a manual courtesy credit, a partial refund recorded against an item, etc.) is silently wiped to 0 on retry.

Marked `@unittest.expectedFailure` so it documents the bug without breaking any suite.

## Notes

The fix is small: before `data['saved_adjustments'] = True` is set later in `updateTotals` (around line 599), capture each item's current `adjustments` into `item.data['_initial_adjustments']` so the reset path has something correct to restore to. The reset block's `Coalesce(..., 0)` default makes today's behavior look intentional but only because the captured value never exists.

## Test plan
- [ ] `python manage.py test danceschool.core.tests.test_cart.BackButtonAdjustmentsResetTest` — should report `OK (expected failures=1)` today
- [ ] After a fix, removing `@unittest.expectedFailure` should yield a passing test