### PR TITLE
Validate Stripe redirect targets and harden webhook signature handling

### DIFF
--- a/danceschool/payments/stripe/tests.py
+++ b/danceschool/payments/stripe/tests.py
@@ -1,0 +1,139 @@
+'''
+Tests for Stripe payment processor views.
+Focused on security-sensitive paths: webhook signature handling and
+redirect-target validation against open-redirect attacks.
+'''
+from types import SimpleNamespace
+from unittest import mock
+
+from django.test import TestCase, override_settings
+from django.urls import reverse
+
+from danceschool.core.models import Invoice
+
+
+@override_settings(STRIPE_WEBHOOK_KEY='whsec_test_dummy_key')
+class StripeWebhookSignatureTest(TestCase):
+    '''
+    Reproduces a bug at danceschool/payments/stripe/views.py:334 where the
+    webhook view dereferences request.META['HTTP_STRIPE_SIGNATURE'] without
+    a guard, raising KeyError (HTTP 500) when the header is absent. A
+    well-behaved webhook endpoint should respond 400 for malformed
+    requests so misconfigured callers see a usable error.
+    '''
+
+    def test_webhook_without_signature_header_returns_400_not_500(self):
+        response = self.client.post(
+            reverse('stripeWebhook'),
+            data='{}',
+            content_type='application/json',
+        )
+        self.assertEqual(
+            response.status_code, 400,
+            msg=(
+                'Webhook without HTTP_STRIPE_SIGNATURE returned %s; '
+                'expected 400 (a bare KeyError → 500 is the bug).'
+            ) % response.status_code,
+        )
+
+
+@override_settings(STRIPE_PRIVATE_KEY='sk_test_dummy_key')
+class StripeHandlerRedirectValidationTest(TestCase):
+    '''
+    Reproduces an open-redirect bug in handle_stripe_checkout
+    (views.py:190, 192). The view reads ``successUrl`` and ``customizeUrl``
+    from POST data and redirects there after a successful charge, with
+    no validation that the target points back to the local site. An
+    attacker who can submit the form can plant an arbitrary off-site URL
+    and the application will redirect the victim's browser to it.
+
+    Stripe SDK calls are mocked so the charge "succeeds" and execution
+    reaches the redirect branch.
+    '''
+
+    EXTERNAL_URL = 'https://evil.example.com/steal'
+
+    def setUp(self):
+        self.invoice = Invoice.objects.create(
+            firstName='Redirect', lastName='Victim',
+            email='redir@victim.test',
+            grossTotal=10, total=10,
+            status=Invoice.PaymentStatus.unpaid,
+        )
+
+    def _post(self, **extra):
+        post_data = {
+            'stripeToken': 'tok_test_dummy',
+            'stripeEmail': self.invoice.email,
+            'invoice_id': str(self.invoice.id),
+            'stripeAmount': '10',
+        }
+        post_data.update(extra)
+        return self.client.post(reverse('stripeHandler'), post_data)
+
+    def _patches(self):
+        '''
+        Stack the mocks needed to reach the redirect branch:
+        - Stripe SDK calls returned by a successful charge.
+        - Invoice.processPayment, which triggers email-template lookup
+          unrelated to this test (a pre-existing dynamic_preferences
+          deserialization issue in the test DB).
+        '''
+        fake_charge = SimpleNamespace(
+            id='ch_test_dummy', amount=1000, status='succeeded',
+            balance_transaction='txn_test_dummy',
+        )
+        fake_txn = SimpleNamespace(fee=30)
+        return [
+            mock.patch.multiple(
+                'danceschool.payments.stripe.views.stripe',
+                Charge=mock.Mock(create=mock.Mock(return_value=fake_charge)),
+                BalanceTransaction=mock.Mock(retrieve=mock.Mock(return_value=fake_txn)),
+                error=mock.Mock(
+                    CardError=Exception, RateLimitError=Exception,
+                    InvalidRequestError=Exception, AuthenticationError=Exception,
+                    APIConnectionError=Exception, StripeError=Exception,
+                ),
+            ),
+            mock.patch.object(Invoice, 'processPayment', return_value=None),
+        ]
+
+    def _post_with_patches(self, **extra):
+        from contextlib import ExitStack
+        with ExitStack() as stack:
+            for p in self._patches():
+                stack.enter_context(p)
+            return self._post(**extra)
+
+    def test_external_success_url_is_rejected(self):
+        response = self._post_with_patches(successUrl=self.EXTERNAL_URL)
+        # Acceptable: a 302 to a SAFE URL (fallback) or any non-2xx
+        # rejection. Not acceptable: redirecting to the attacker URL.
+        location = response.get('Location', '')
+        self.assertNotIn(
+            'evil.example.com', location,
+            msg=(
+                'Open redirect: handle_stripe_checkout redirected to '
+                'attacker-supplied successUrl %r' % location
+            ),
+        )
+
+    def test_external_customize_url_is_rejected(self):
+        response = self._post_with_patches(
+            addSessionInfo='true',
+            customizeUrl=self.EXTERNAL_URL,
+        )
+        location = response.get('Location', '')
+        self.assertNotIn(
+            'evil.example.com', location,
+            msg=(
+                'Open redirect: handle_stripe_checkout redirected to '
+                'attacker-supplied customizeUrl %r' % location
+            ),
+        )
+
+    def test_local_success_url_is_allowed(self):
+        '''Regression guard: legitimate same-host URLs must still work.'''
+        response = self._post_with_patches(successUrl='/registration/summary/')
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response['Location'], '/registration/summary/')

--- a/danceschool/payments/stripe/views.py
+++ b/danceschool/payments/stripe/views.py
@@ -4,6 +4,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.shortcuts import redirect
 from django.urls import reverse
 from django.contrib.auth.models import User
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.translation import gettext_lazy as _
 from django.utils import timezone
 from django.views.decorators.csrf import csrf_exempt
@@ -22,6 +23,27 @@ from datetime import timedelta
 
 # Define logger for this file
 logger = logging.getLogger(__name__)
+
+
+def _safe_redirect_url(url, request, fallback):
+    '''
+    Return ``url`` if it points back to the current host, otherwise
+    ``fallback``. Used to guard HttpResponseRedirect targets that
+    originate from client-supplied POST data or webhook metadata
+    (which itself echoes client-supplied values back from Stripe).
+    Without this guard the views become open redirects.
+    '''
+    allowed_hosts = {request.get_host()}
+    if url and url_has_allowed_host_and_scheme(
+        url, allowed_hosts=allowed_hosts, require_https=request.is_secure()
+    ):
+        return url
+    if url:
+        logger.warning(
+            'Rejected unsafe redirect target "%s"; falling back to %s.',
+            url, fallback,
+        )
+    return fallback
 
 
 def handle_stripe_checkout(request):
@@ -187,9 +209,13 @@ def handle_stripe_checkout(request):
                 'successUrl': successUrl,
             })
             request.session[PAYMENT_VALIDATION_STR] = paymentSession
-            return HttpResponseRedirect(customizeUrl)
+            return HttpResponseRedirect(_safe_redirect_url(
+                customizeUrl, request, fallback=reverse('registration'),
+            ))
 
-        return HttpResponseRedirect(successUrl)
+        return HttpResponseRedirect(_safe_redirect_url(
+            successUrl, request, fallback=reverse('registration'),
+        ))
 
     else:
         this_invoice.status = Invoice.PaymentStatus.error
@@ -331,7 +357,9 @@ def create_checkout_session(request):
 def webhook(request):
     payload = request.body
     endpoint_secret = settings.STRIPE_WEBHOOK_KEY
-    sig_header = request.META['HTTP_STRIPE_SIGNATURE']
+    sig_header = request.META.get('HTTP_STRIPE_SIGNATURE')
+    if not sig_header:
+        return HttpResponse(status=400)
     event = None
 
     try:
@@ -423,10 +451,16 @@ def finish_order(charge, metadata, request):
         })
         request.session[PAYMENT_VALIDATION_STR] = paymentSession
         if 'customizeUrl' in metadata:
-            return HttpResponseRedirect(metadata['customizeUrl'])
+            return HttpResponseRedirect(_safe_redirect_url(
+                metadata['customizeUrl'], request,
+                fallback=reverse('registration'),
+            ))
 
     if 'successUrl' in metadata:
-        return HttpResponseRedirect(metadata['successUrl'])
+        return HttpResponseRedirect(_safe_redirect_url(
+            metadata['successUrl'], request,
+            fallback=reverse('registration'),
+        ))
 
 
 class SuccessView(TemplateView):


### PR DESCRIPTION
## Summary

Two security fixes in `danceschool/payments/stripe/views.py`:

### 1. Open-redirect via Stripe checkout success/customize URLs (CRITICAL)

`handle_stripe_checkout` (lines 190, 192) and the webhook's `finish_order` helper (lines 426, 429) all called `HttpResponseRedirect` on `successUrl` / `customizeUrl` pulled from client-supplied POST data (which Stripe round-trips back through `metadata`) with no validation that the target points at the current host. An attacker who can submit the Stripe-Checkout-style POST can plant an arbitrary off-site URL and the application will redirect the victim's browser there.

Added a `_safe_redirect_url(url, request, fallback)` helper that uses Django's `url_has_allowed_host_and_scheme` to confirm the target points back at the current host (and respects HTTPS when the request is secure), falling back to the registration page (with a logged warning) on mismatch. Wraps each of the four call sites.

### 2. Webhook signature header `KeyError` → 500 (HIGH)

`webhook` (line 334) dereferenced `request.META['HTTP_STRIPE_SIGNATURE']` without a guard. Misconfigured callers — or a malformed request — produced a 500 instead of the 400 a webhook endpoint should return for malformed input. Switched to `.get()` and return 400 if the header is absent.

## Verification

- New `danceschool/payments/stripe/tests.py` with 4 tests covering both behaviors. All pass.
- 64 tests in payments + discounts + vouchers suites pass with no new regressions (2 pre-existing `payatdoor` failures around CMS plugin registration are unrelated and reproduce on `0.9.0-dev` without this PR).

```
test_external_customize_url_is_rejected ... ok
test_external_success_url_is_rejected ... ok
test_local_success_url_is_allowed ... ok
test_webhook_without_signature_header_returns_400_not_500 ... ok
```

## Out of scope

The same pattern (`HttpResponseRedirect` of unvalidated POST URLs) exists in `danceschool/payments/square/views.py:241`. Worth a separate PR so this one stays focused; happy to write that next.

## Test plan
- [ ] `python manage.py test danceschool.payments.stripe` — 4 passing
- [ ] Review the `_safe_redirect_url` helper choice — accepts current host + requires HTTPS when the request was secure
- [ ] Confirm the fallback URL (`reverse('registration')`) is right for these checkout paths; alternatives are `reverse('cartSummary')` or `reverse('stripeCanceled')`