### PR TITLE
Fix GiftCertificateCustomizeView reading wrong session keys (silent payment-without-voucher bug)

### DIFF
--- a/danceschool/vouchers/tests.py
+++ b/danceschool/vouchers/tests.py
@@ -5,7 +5,9 @@ from django.utils import timezone
 
 from datetime import timedelta
 
-from danceschool.core.constants import REG_VALIDATION_STR, updateConstant
+from danceschool.core.constants import (
+    REG_VALIDATION_STR, PAYMENT_VALIDATION_STR, updateConstant
+)
 from danceschool.core.models import Registration, Invoice
 from danceschool.core.tests.defaults import DefaultSchoolTestCase
 
@@ -419,3 +421,56 @@ class CartSummaryVoucherPreviewTest(VouchersTest):
 
         self.assertEqual(response.status_code, 200)
         self.assertIsNone(response.context_data.get('voucher_preview'))
+
+
+class GiftCertificateCustomizeViewSessionKeysTest(DefaultSchoolTestCase):
+    '''
+    Regression coverage for GiftCertificateCustomizeView's session-key lookup.
+
+    All three payment providers (Stripe, PayPal, Square) write the
+    PAYMENT_VALIDATION_STR session dict using camelCase keys: 'invoiceID',
+    'amount', 'successUrl'. The customize view must read those same keys; if
+    it looks up snake_case keys instead, every successful gift certificate
+    purchase 400s on the post-payment redirect and no Voucher is ever issued
+    (the customer is charged with nothing to show for it).
+    '''
+
+    def _set_payment_session(self, invoice, amount, success_url='/done/'):
+        session = self.client.session
+        session[PAYMENT_VALIDATION_STR] = {
+            'invoiceID': str(invoice.id),
+            'amount': amount,
+            'successUrl': success_url,
+        }
+        session.save()
+
+    def test_paid_invoice_with_camelcase_session_keys_renders_form(self):
+        '''
+        With the camelCase keys the payment views actually write, the
+        customize view must locate the paid invoice and render the form
+        (200), not return 400 'Invalid invoice information passed.'
+        '''
+        invoice = Invoice.objects.create(
+            grossTotal=10, total=10, amountPaid=10,
+            status=Invoice.PaymentStatus.paid,
+        )
+        self._set_payment_session(invoice, amount=10)
+
+        response = self.client.get(reverse('customizeGiftCertificate'))
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_unpaid_invoice_returns_400(self):
+        '''
+        Sanity-check the second guard: even with correct keys, an unpaid
+        invoice must still 400 with 'Passed invoice is not paid.'
+        '''
+        invoice = Invoice.objects.create(
+            grossTotal=10, total=10, amountPaid=0,
+            status=Invoice.PaymentStatus.unpaid,
+        )
+        self._set_payment_session(invoice, amount=10)
+
+        response = self.client.get(reverse('customizeGiftCertificate'))
+
+        self.assertEqual(response.status_code, 400)

--- a/danceschool/vouchers/views.py
+++ b/danceschool/vouchers/views.py
@@ -37,9 +37,9 @@ class GiftCertificateCustomizeView(FormView):
         and that said invoice is marked as paid.
         '''
         paymentSession = request.session.get(PAYMENT_VALIDATION_STR, {})
-        self.invoice_id = paymentSession.get('invoice_id')
+        self.invoice_id = paymentSession.get('invoiceID')
         self.amount = paymentSession.get('amount', 0)
-        self.success_url = paymentSession.get('success_url', reverse('registration'))
+        self.success_url = paymentSession.get('successUrl', reverse('registration'))
 
         # Check that Invoice matching passed ID exists
         try:


### PR DESCRIPTION
## Summary

`GiftCertificateCustomizeView.dispatch` reads the payment-validation session dict using **snake_case** keys, but all three payment providers (Stripe, PayPal, Square) write it using **camelCase**. As a result, `self.invoice_id` is always `None`, `Invoice.objects.get(id=None)` raises `DoesNotExist`, and **every successful gift certificate purchase** 400s on the post-payment redirect with `"Invalid invoice information passed."`

The customer's card is charged, an `Invoice` row is created and marked `paid`, the generic invoice receipt email goes out — but `form_valid` is never reached, so `Voucher.create_new_code(prefix='GC_', ...)` never runs and **no voucher is ever issued**. The customer is left with a paid invoice and no gift certificate.

This affects gift certificate purchases on **all three** payment providers.

### Reproduction (real, in production)

I just hit this with a $0.50 live test on a deployed site using the Square provider:

- Square dashboard shows the $0.50 payment as successful.
- The site emailed the standard payment confirmation with `Invoice ID: #9005d41a-…`, `Status: Paid`, `Amount Paid: $0.50`.
- Browser DevTools showed `GET /gift_certificate/customize/` returned **400** with body `Invalid invoice information passed.`
- No `Voucher` row was created.

### Root cause

`danceschool/vouchers/views.py:40,42` (the reader):

```python
self.invoice_id = paymentSession.get('invoice_id')   # writers use 'invoiceID'
self.amount = paymentSession.get('amount', 0)        # ✓ matches
self.success_url = paymentSession.get('success_url', reverse('registration'))  # writers use 'successUrl'
```

All three writers use camelCase:

- `payments/stripe/views.py:184-187` (`invoiceID`, `amount`, `successUrl`)
- `payments/stripe/views.py:419-422` (same keys)
- `payments/paypal/views.py:237-240` (same keys)
- `payments/square/views.py:234-237` (same keys)

Git history shows the divergence came in during the `0.9.0-dev` refactor (commit `c368dcd` — "Initial commit of registration process refactor to REST serializer and signal handlers for easier customizability"), which renamed only the reader and missed the four writer sites.

## The fix

Single-line change in the reader to match the writer convention used by every payment provider. Touching the reader keeps Stripe / PayPal / Square consistent and avoids a four-site change.

## Tests

Added `GiftCertificateCustomizeViewSessionKeysTest` in `danceschool/vouchers/tests.py`:

- `test_paid_invoice_with_camelcase_session_keys_renders_form` — writes the session exactly as the payment views do (camelCase), GETs the customize URL, asserts `200`. **Fails (`400 != 200`) on master, passes with the fix.**
- `test_unpaid_invoice_returns_400` — sanity check that the second guard (`Passed invoice is not paid.`) still works.

Full vouchers suite (35 tests) passes.

## Test plan

- [x] Failing test reproduces the production 400 before the fix.
- [x] Both new tests pass with the fix.
- [x] Full `danceschool.vouchers` test suite (35 tests) passes.
- [ ] Verify on a deployed instance: $0.50 gift cert purchase via Square → redirects to the customize form (no 400) → voucher is created and emailed.

## Related

Adjacent to the v0.10 cart/discount work in #174–#179. This one is a separate silent-failure bug — flagging because anyone whose card cleared on the gift-cert page in 0.9.0-dev has been charged with no voucher delivered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)