### PR TITLE
Reduce N+1 queries on the class registration page

### DIFF
--- a/danceschool/core/classreg.py
+++ b/danceschool/core/classreg.py
@@ -1,7 +1,7 @@
 from django.urls import reverse
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.contrib import messages
-from django.db.models import Q
+from django.db.models import Prefetch, Q
 from django.http import HttpResponseRedirect, Http404, JsonResponse
 from django.views.generic import FormView, RedirectView, TemplateView, View
 from django.utils.translation import gettext, gettext_lazy as _
@@ -16,7 +16,8 @@ from braces.views import PermissionRequiredMixin
 
 from .models import (
     Event, Series, PublicEvent, Invoice, InvoiceItem, Customer,
-    CashPaymentRecord, DanceRole, Registration, EventRegistration
+    CashPaymentRecord, DanceRole, Registration, EventRegistration,
+    EventOccurrence, SeriesTeacher,
 )
 from .forms import (
     ClassChoiceForm, RegistrationContactForm, MultiRegCustomerNameForm,
@@ -337,7 +338,19 @@ class ClassRegistrationView(FinancialContextMixin, EventOrderMixin, SiteHistoryM
                 Q(status=Event.RegStatus.hidden) |
                 Q(status=Event.RegStatus.regHidden) |
                 Q(status=Event.RegStatus.linkOnly)
-            ).order_by(*self.get_ordering())
+            ).order_by(*self.get_ordering()).select_related(
+                'location', 'room', 'polymorphic_ctype',
+            ).prefetch_related(
+                Prefetch(
+                    'eventoccurrence_set',
+                    queryset=EventOccurrence.objects.order_by('startTime'),
+                ),
+                Prefetch(
+                    'eventstaffmember_set',
+                    queryset=SeriesTeacher.objects.select_related('staffMember'),
+                    to_attr='_prefetched_teachers',
+                ),
+            )
 
         return self.allEvents
 

--- a/danceschool/core/models.py
+++ b/danceschool/core/models.py
@@ -1123,11 +1123,18 @@ class Event(EmailRecipientMixin, PolymorphicModel):
 
     @property
     def numOccurrences(self):
+        cache = self.__dict__.get('_prefetched_objects_cache', {})
+        if 'eventoccurrence_set' in cache:
+            return len(cache['eventoccurrence_set'])
         return self.eventoccurrence_set.count()
     numOccurrences.fget.short_description = _('# Occurrences')
 
     @property
     def firstOccurrence(self):
+        cache = self.__dict__.get('_prefetched_objects_cache', {})
+        if 'eventoccurrence_set' in cache:
+            occurrences = cache['eventoccurrence_set']
+            return occurrences[0] if occurrences else None
         return self.eventoccurrence_set.order_by('startTime').first()
     firstOccurrence.fget.short_description = _('First occurrence')
 
@@ -1767,6 +1774,9 @@ class Series(Event):
     )
 
     def getTeachers(self, includeSubstitutes=False):
+        if not includeSubstitutes and hasattr(self, '_prefetched_teachers'):
+            return list(set(t.staffMember for t in self._prefetched_teachers))
+
         seriesTeachers = SeriesTeacher.objects.filter(event=self)
         seriesTeachers = set([t.staffMember for t in seriesTeachers])
 


### PR DESCRIPTION
  ## Problem
  
Boston Lindy Hop had an issue about a year ago where our server crashed due to so many students trying to register for class at the same time. As a temporary fix we increased the size of our Digital Ocean Instance.

After making some time to do a dive into registration I discovered the `/register/` page was issuing roughly 8 extra DB queries per event displayed:

  - `Event.numOccurrences` → `eventoccurrence_set.count()`
  - `Event.firstOccurrence` → `eventoccurrence_set.order_by('startTime').first()`
  - `Series.getTeachers` → `SeriesTeacher.objects.filter(event=self)`
  - `event.eventoccurrence_set.all` in the default template
  - `event.location` and `event.room` FK lookups

With 10 open events this means ~90 queries just to render the registration page, which causes noticeable slowdowns during high-traffic registration periods. This PR is to solve the N+1 query issues and drastically decrease the number of queries to the DB during registration.