### PR TITLE
Fix events_grouped_list.html: sort inner regroup on 'sorter' 

### DIFF
--- a/danceschool/core/templates/core/events_grouped_list.html
+++ b/danceschool/core/templates/core/events_grouped_list.html
@@ -8,7 +8,7 @@
     {% for groupFirst in group_list %}
         <li><h4>{{ groupFirst.grouper }} {% if instance.eventType == 'S' %}{% trans "Classes" %}{% else %}{% trans "Events" %}{% endif %}</h4></li>
 
-        {% regroup groupFirst.list|dictsort:"organizer.nameSecond.grouper" by organizer.nameSecond.name as groupSecond_list %}
+        {% regroup groupFirst.list|dictsort:"organizer.nameSecond.sorter" by organizer.nameSecond.name as groupSecond_list %}
         {% for groupSecond in groupSecond_list %}
             {% if groupSecond.grouper %}<h5>{{ groupSecond.grouper }}</h5>{% endif %}
             <ul>            


### PR DESCRIPTION
Previously on the Boston Lindy Hop website `upcoming classes` and `upcoming events` were not populating at https://bostonlindyhop.com/news/. We fixed that with a monkeypatch I'm submitting this PR to address it in the Django Dance School.

The issue is organizer.nameSecond never has a 'grouper' key, only 'name' and 'sorter'. dictsort silently swallows the resulting lookup failure and returns '', so the inner regroup produces no groups and no event/class items render under each header.