### PR TITLE
Fix voucher double-subtract (DiscountCombo + Voucher) and back-button reset dropping prior adjustments

### DIFF
--- a/danceschool/core/models/invoices.py
+++ b/danceschool/core/models/invoices.py
@@ -406,6 +406,26 @@ class Invoice(EmailRecipientMixin, models.Model):
             k in item_keys
         }
 
+        # Capture each item's pre-application `total` and `adjustments` into
+        # its own data dict so the back-button reset block below can restore
+        # them faithfully. Without this, an item created with a non-zero
+        # adjustment (e.g. a manual courtesy credit applied before a discount
+        # is computed) would be wiped to 0 on the retry pass because the
+        # reset's Coalesce(...) defaults to 0 when the key is absent. Items
+        # that already have `_initial_*` captured are not re-captured.
+        for item in self.invoiceitem_set.all():
+            item_data = item.data or {}
+            captured = False
+            if '_initial_adjustments' not in item_data:
+                item_data['_initial_adjustments'] = item.adjustments
+                captured = True
+            if '_initial_total' not in item_data:
+                item_data['_initial_total'] = item.total
+                captured = True
+            if captured:
+                item.data = item_data
+                item.save(updateInvoiceTotals=False)
+
         # If the invoice has previously been saved with adjustments
         # but it is still a preliminary invoice,
         # then we need to un-apply those previous adjustments by starting with

--- a/danceschool/core/tests/test_cart.py
+++ b/danceschool/core/tests/test_cart.py
@@ -555,7 +555,6 @@ class BackButtonAdjustmentsResetTest(DefaultSchoolTestCase):
     pre-existing non-discount adjustment is silently wiped to 0 on retry.
     '''
 
-    @unittest.expectedFailure
     def test_back_button_preserves_prior_non_discount_adjustments(self):
         series = self.create_series(pricingTier=self.defaultPricing)
         invoice = Invoice.objects.create(

--- a/danceschool/core/tests/test_cart.py
+++ b/danceschool/core/tests/test_cart.py
@@ -1,8 +1,9 @@
 import json
+import unittest
 
 from django.urls import reverse
 
-from ..models import Registration, Invoice, EventRole
+from ..models import Registration, Invoice, InvoiceItem, EventRole
 from ..constants import updateConstant, REG_VALIDATION_STR
 from .defaults import DefaultSchoolTestCase
 
@@ -543,3 +544,47 @@ class CartSummaryViewTest(DefaultSchoolTestCase):
         items = self.client.session[REG_VALIDATION_STR]['cart']['items']
         self.assertEqual(len(items), 1)
         self.assertEqual(items[0]['sku'], f'EVENT_{series.id}_GENERAL')
+
+
+class BackButtonAdjustmentsResetTest(DefaultSchoolTestCase):
+    '''
+    Reproduces a bug in Invoice.updateTotals where the back-button reset
+    path (invoices.py:416-432) restores each item's `adjustments` from
+    `data._initial_adjustments`, defaulting to 0 when that key is absent.
+    The key is never captured anywhere on the original pass, so any
+    pre-existing non-discount adjustment is silently wiped to 0 on retry.
+    '''
+
+    @unittest.expectedFailure
+    def test_back_button_preserves_prior_non_discount_adjustments(self):
+        series = self.create_series(pricingTier=self.defaultPricing)
+        invoice = Invoice.objects.create(
+            firstName='Back', lastName='Button', email='back@test.com',
+            grossTotal=series.getBasePrice(),
+            total=series.getBasePrice(),
+            status=Invoice.PaymentStatus.preliminary,
+        )
+        item = InvoiceItem.objects.create(
+            invoice=invoice,
+            grossTotal=series.getBasePrice(),
+            total=series.getBasePrice(),
+            adjustments=-3,
+            data={'_initial_total': series.getBasePrice()},
+        )
+        invoice.adjustments = -3
+        invoice.data['saved_adjustments'] = True
+        invoice.save()
+
+        # Simulate the back-button retry path: updateTotals runs again on
+        # the still-preliminary invoice, sees saved_adjustments=True, and
+        # resets per-item totals/adjustments before re-applying anything.
+        invoice.updateTotals(save=True)
+
+        item.refresh_from_db()
+        self.assertEqual(
+            item.adjustments, -3,
+            msg=(
+                'Prior non-discount adjustment of -3 was wiped to {0} '
+                'because _initial_adjustments was never captured.'
+            ).format(item.adjustments),
+        )

--- a/danceschool/discounts/tests.py
+++ b/danceschool/discounts/tests.py
@@ -777,7 +777,6 @@ class DoubleSubtractionWhenCodeInBothTablesTest(BaseDiscountsTest):
     with no guard for the case where the same code matched both systems.
     '''
 
-    @unittest.expectedFailure
     def test_shared_code_not_double_subtracted(self):
         updateConstant('general__discountsEnabled', True)
         updateConstant('vouchers__enableVouchers', True)

--- a/danceschool/discounts/tests.py
+++ b/danceschool/discounts/tests.py
@@ -1,4 +1,5 @@
 import json
+import unittest
 
 from django.forms.models import model_to_dict
 from django.urls import reverse
@@ -9,6 +10,7 @@ from datetime import timedelta
 from danceschool.core.constants import REG_VALIDATION_STR, updateConstant
 from danceschool.core.tests.defaults import DefaultSchoolTestCase
 from danceschool.core.models import Invoice, Registration
+from danceschool.vouchers.models import Voucher
 
 from .models import (
     PointGroup, PricingTierGroup, DiscountCategory, DiscountCombo, DiscountComboComponent
@@ -761,3 +763,66 @@ class CartSummaryDiscountPreviewTest(BaseDiscountsTest):
         preview = response.context_data.get('discount_preview')
         self.assertIsNotNone(preview)
         self.assertGreater(preview['total_discount'], 0)
+
+
+class DoubleSubtractionWhenCodeInBothTablesTest(BaseDiscountsTest):
+    '''
+    Reproduces a bug where a code registered in BOTH DiscountCombo
+    (with voucherId set) AND the Voucher table causes the CartSummaryView
+    to subtract the discount AND the voucher amount from the user-facing
+    net total, double-counting the price reduction.
+
+    CartSummaryView.get_context_data (cart.py:758-761) subtracts the
+    discount_preview total and the voucher_preview amount independently,
+    with no guard for the case where the same code matched both systems.
+    '''
+
+    @unittest.expectedFailure
+    def test_shared_code_not_double_subtracted(self):
+        updateConstant('general__discountsEnabled', True)
+        updateConstant('vouchers__enableVouchers', True)
+
+        s = self.create_series(pricingTier=self.defaultPricing)
+        gross = s.getBasePrice()
+
+        # Same code in both tables.
+        self.create_discount(
+            voucherId='DBLCODE',
+            discountType=DiscountCombo.DiscountType.dollarDiscount,
+            dollarDiscount=10,
+        )
+        Voucher.objects.create(
+            voucherId='DBLCODE',
+            name='Shared Code Voucher',
+            originalAmount=5,
+            disabled=False,
+        )
+
+        # Set up cart with the shared code and view the summary.
+        sku = f'EVENT_{s.id}_GENERAL'
+        cart = {
+            'items': [{'item_type': 'Event', 'item_id': s.id,
+                       'sku': sku, 'quantity': 1}],
+            'payAtDoor': False,
+            'discount_code': 'DBLCODE',
+        }
+        session = self.client.session
+        session[REG_VALIDATION_STR] = {'cart': cart, 'payAtDoor': False}
+        session.save()
+
+        response = self.client.get(reverse('cartSummary'))
+        self.assertEqual(response.status_code, 200)
+        net_total = response.context_data.get('net_total')
+
+        # Whatever the correct resolution (apply only the discount, only
+        # the voucher, or treat as ambiguous), it must NOT be both.
+        # Current buggy behavior: gross - 10 - 5 = gross - 15.
+        # Acceptable: net_total >= gross - max(10, 5) = gross - 10.
+        self.assertGreaterEqual(
+            net_total, gross - 10,
+            msg=(
+                'Code present in both DiscountCombo (voucherId) and '
+                'Voucher tables produced over-discounted net_total {0} '
+                '(gross {1}); expected at least {2}.'
+            ).format(net_total, gross, gross - 10),
+        )

--- a/danceschool/vouchers/handlers.py
+++ b/danceschool/vouchers/handlers.py
@@ -129,6 +129,14 @@ def checkVoucherCode(sender, **kwargs):
     validate_customer = kwargs.get('validateCustomer', False)
     pay_at_door = kwargs.get('payAtDoor', None)
 
+    # If the same code is registered as a DiscountCombo voucherId, defer to
+    # the discounts app so the cart preview doesn't subtract the discount and
+    # the voucher amount both. Mirrors validateVoucher above.
+    if voucherId and apps.is_installed('danceschool.discounts'):
+        discount_models = import_module('danceschool.discounts.models')
+        if discount_models.DiscountCombo.objects.filter(voucherId=voucherId).exists():
+            return
+
     errors = []
 
     if not voucherId:


### PR DESCRIPTION
## Summary

Combines the fixes for two cart/discount bugs previously filed as test-only reproducers (#176, #177). Both `@expectedFailure` decorators removed; tests now pass.

**Please close #176 and #177 in favor of this PR.** Their branches are stale; the fix commits here supersede them.

## Bug 1: Voucher double-subtracted when code exists in DiscountCombo and Voucher (was #176)

`CartSummaryView` subtracted both the discount and the voucher amount from `net_total` when the same code was registered in both tables.

**Root cause:** `_get_voucher_preview` didn't check whether the code was claimed by a DiscountCombo first.

**Fix:** mirror the existing pattern in `vouchers/handlers.py:86-90` (the form-path `validateVoucher` already yields to DiscountCombo). Add the same early-return at the top of `checkVoucherCode`.

**Design call:** made without maintainer input. The form-path yielding to DiscountCombo is prior art, so the preview path yielding too is the least-surprise fix. NCS custom code doesn't override either path.

## Bug 2: Back-button reset silently wipes pre-existing non-discount adjustments (was #177)

The reset block at `invoices.py:416-432` restored `InvoiceItem` adjustments from `data._initial_adjustments`, but `_initial_adjustments` was never captured on the original pass — so `Coalesce(..., 0)` wiped any prior manual adjustment (e.g. a courtesy credit) to 0 on retry.

**Fix:** before the reset block, iterate items and capture `_initial_total` / `_initial_adjustments` into each item's `data` dict if not already present.

**Design call:** made without maintainer input. Incremental patch rather than a redesign of the initial-capture pass.

## Tests

Both original PRs' `@expectedFailure` reproducer tests are included unmodified minus the decorators. Full `discounts` (26 tests) and `core.tests.test_cart` (36 tests) suites stay green.