### PR TITLE
Fix three merch cart checkout bugs (requireFull redirect, shadowed gettext, quantity expansion)

### DIFF
--- a/danceschool/core/views/cart.py
+++ b/danceschool/core/views/cart.py
@@ -49,6 +49,20 @@ def clear_reg_cart(request):
         request.session.modified = True
 
 
+def _cart_requires_student_info(cart_items):
+    '''
+    Return True if any cart item requires the Step 2 student-information form.
+    Items without an explicit requireFull flag default to True so event
+    registrations (which historically never carried the flag) preserve their
+    current behavior; a merch-only cart whose plugin has
+    requireFullRegistration=False can then bypass Step 2 by populating
+    requireFull=False on each item.
+    '''
+    if not cart_items:
+        return True
+    return any(item.get('requireFull', True) for item in cart_items)
+
+
 class PurchasableItemPagination(PageNumberPagination):
     page_size = 20
 
@@ -447,7 +461,10 @@ class CartView(RegistrationAdjustmentsMixin, APIView):
         return None
 
     def get_success_url(self):
-        return reverse('getStudentInfo')
+        cart = self.request.session.get(REG_VALIDATION_STR, {}).get('cart', {})
+        if _cart_requires_student_info(cart.get('items', [])):
+            return reverse('getStudentInfo')
+        return reverse('showRegSummary')
 
     def dispatch(self, request, *args, **kwargs):
         '''
@@ -860,6 +877,8 @@ class CartSummaryView(RegistrationAdjustmentsMixin, TemplateView):
             reg_session['invoice_expiry'] = invoice.expirationDate.isoformat()
             reg_session['payAtDoor'] = self.payAtDoor
             request.session.modified = True
-            return HttpResponseRedirect(reverse('getStudentInfo'))
+            if _cart_requires_student_info(cart.get('items', [])):
+                return HttpResponseRedirect(reverse('getStudentInfo'))
+            return HttpResponseRedirect(reverse('showRegSummary'))
 
         return HttpResponseRedirect(reverse('cartSummary'))

--- a/danceschool/core/views/cart.py
+++ b/danceschool/core/views/cart.py
@@ -226,9 +226,16 @@ class CartView(RegistrationAdjustmentsMixin, APIView):
             invoice.invoiceitem_set.all().delete()
 
         # Expand items with quantity > 1 into multiple single-quantity items so
-        # that each person in a group registration gets their own EventRegistration.
+        # that each person in a group registration gets their own
+        # EventRegistration. Merch items are pass-through: the merch handler
+        # records quantity directly on the MerchOrderItem, and expanding
+        # produces duplicate rows that trip the "same variant added multiple
+        # times" guard in linkCartMerchOrderItems.
         expanded = []
         for item in item_data:
+            if item.get('item_type') == 'MerchItem':
+                expanded.append(item)
+                continue
             qty = max(1, int(item.get('quantity') or 1))
             for _qty_i in range(qty):
                 expanded.append({**item, 'quantity': 1})

--- a/danceschool/merch/handlers.py
+++ b/danceschool/merch/handlers.py
@@ -306,7 +306,7 @@ def linkCartMerchOrderItems(sender, **kwargs):
     # Identify whether this is a merch item via the purchasable registry.
     # This avoids any reliance on SKU format conventions.
     this_merch_item = None
-    for qs, _ in purchasable_registry:
+    for qs, _serializer in purchasable_registry:
         if qs.model == MerchItem:
             try:
                 this_merch_item = qs.get(id=item_id)

--- a/danceschool/merch/tests.py
+++ b/danceschool/merch/tests.py
@@ -181,6 +181,47 @@ class MerchCartCheckoutTest(DefaultSchoolTestCase):
         )
         self.assertEqual(response.status_code, 400)
 
+    def test_merch_only_cart_with_require_full_false_skips_student_info(self):
+        '''
+        A merch-only cart whose items all carry requireFull=False (reflecting
+        the merch plugin's requireFullRegistration checkbox being unchecked)
+        should skip StudentInfoView (Step 2) at checkout and redirect straight
+        to showRegSummary.
+        '''
+        response = self._door_cart_post(
+            items=[{
+                'item_type': 'MerchItem',
+                'item_id': self.item.id,
+                'sku': self.variant.sku,
+                'quantity': 1,
+                'requireFull': False,
+            }],
+            checkout=True,
+        )
+        self.assertRedirects(
+            response, reverse('showRegSummary'), fetch_redirect_response=False
+        )
+
+    def test_merch_cart_with_require_full_true_still_routes_to_student_info(self):
+        '''
+        When an item carries requireFull=True (or the flag is absent, per the
+        safe default), the checkout redirect must still go to StudentInfoView.
+        This guards the existing behavior for event registrations and for
+        merch plugins that have requireFullRegistration checked.
+        '''
+        response = self._door_cart_post(
+            items=[{
+                'item_type': 'MerchItem',
+                'item_id': self.item.id,
+                'sku': self.variant.sku,
+                'quantity': 1,
+                'requireFull': True,
+            }],
+            checkout=True,
+        )
+        self.assertRedirects(
+            response, reverse('getStudentInfo'), fetch_redirect_response=False
+        )
 
 class MerchStudentInfoViewTest(DefaultSchoolTestCase):
     '''

--- a/danceschool/merch/tests.py
+++ b/danceschool/merch/tests.py
@@ -223,6 +223,39 @@ class MerchCartCheckoutTest(DefaultSchoolTestCase):
             response, reverse('getStudentInfo'), fetch_redirect_response=False
         )
 
+    def test_merch_checkout_with_quantity_greater_than_one(self):
+        '''
+        A merch item purchased with quantity>1 must produce a single
+        MerchOrderItem with the correct quantity, not multiple qty=1 rows.
+        Regression for the per-item cart-expansion pass in
+        create_invoice_from_cart, which is required for events (one
+        EventRegistration per attendee) but produces spurious duplicate
+        detections for merchandise.
+        '''
+        from danceschool.merch.models import MerchOrder, MerchOrderItem
+        response = self._door_cart_post(
+            items=[{
+                'item_type': 'MerchItem',
+                'item_id': self.item.id,
+                'sku': self.variant.sku,
+                'quantity': 2,
+            }],
+            checkout=True,
+        )
+        self.assertEqual(
+            response.status_code, 302,
+            'Multi-quantity merch checkout must succeed (not 400 on duplicate).',
+        )
+        invoice = Invoice.objects.get(
+            id=self.client.session[REG_VALIDATION_STR]['invoice_id']
+        )
+        order = MerchOrder.objects.get(invoice=invoice)
+        order_items = list(MerchOrderItem.objects.filter(order=order, item=self.variant))
+        self.assertEqual(len(order_items), 1, 'Expect one MerchOrderItem, not multiple.')
+        self.assertEqual(order_items[0].quantity, 2)
+        self.assertAlmostEqual(invoice.grossTotal, self.item.defaultPrice * 2, places=2)
+
+
 class MerchStudentInfoViewTest(DefaultSchoolTestCase):
     '''
     Tests that StudentInfoView correctly reflects the contents of a

--- a/danceschool/register/static/js/manage_register_cart.js
+++ b/danceschool/register/static/js/manage_register_cart.js
@@ -65,7 +65,7 @@ document.addEventListener('DOMContentLoaded', function () {
         }
 
         if (raw.type === 'MerchItem' || raw.type === 'merch' || raw.type === 'merchItem') {
-            return {
+            const item = {
                 item_type: 'MerchItem',
                 item_id: parseInt(raw.itemId),
                 sku: raw.sku,
@@ -74,6 +74,10 @@ document.addEventListener('DOMContentLoaded', function () {
                 description: raw.description || null,
                 price: raw.price ? parseFloat(raw.price) : null,
             };
+            if (raw.requireFull !== undefined) { item.requireFull = isTruthy(raw.requireFull); }
+            if (raw.autoSubmit !== undefined) { item.autoSubmit = isTruthy(raw.autoSubmit); }
+            if (raw.autoFulfill !== undefined) { item.autoFulfill = isTruthy(raw.autoFulfill); }
+            return item;
         }
 
         // Unknown type — pass through as-is and let the server validate.


### PR DESCRIPTION
Three related bugs found while browser-testing a merch-only checkout. Each is a separate commit.

## 1. `requireFullRegistration` never consumed at checkout redirect

The `requireFull` flag flows into `CartItemSerializer.requireFull` per item but neither `CartView.get_success_url` nor `CartSummaryView.post`'s checkout branch reads it back out. Both unconditionally redirect to `getStudentInfo`. Also, the merch branch of `translateButtonData` in `manage_register_cart.js` never extracts `requireFull` from the button dataset (only the eventRegistration branch did), so the flag never even reached the server.

**Fix:** helper `_cart_requires_student_info(items)` (missing flag defaults to `True`, preserving current event behavior) consulted by both redirect sites. JS merch branch now extracts `requireFull` / `autoSubmit` / `autoFulfill` like the event branch. Two tests cover the skip and default-preserved paths.

## 2. `_` gettext shadowed by loop variable in `linkCartMerchOrderItems`

`for qs, _ in purchasable_registry:` (added in #189) shadows the imported gettext `_`, so `_(...).format(...)` calls further down crash with `AttributeError: 'MerchItemSerializer' object has no attribute 'format'` when the duplicate-variant error path fires.

**Fix:** rename the loop variable to `_serializer`.

## 3. `MerchItem` items get expanded from `quantity=N` into N duplicate rows

`create_invoice_from_cart` expands every `quantity>1` item into single-quantity copies so each event attendee gets their own `EventRegistration`. For merch this produces duplicate rows that trip the duplicate-variant guard, blocking any multi-quantity merch purchase.

**Fix:** skip the expansion for `item_type == 'MerchItem'`. Regression test asserts `quantity=2` checkout produces one `MerchOrderItem` with `quantity=2` and correct `grossTotal`.

## Interlock

Bug 3 creates duplicate rows, which triggers the merch handler's duplicate guard, which then can't render its error message because of bug 2 (surfaces as a 500 instead of 400). Bug 1 is the user-visible symptom (merch-only cart still routed through Step 2).

## Test plan

- [x] \`python manage.py test danceschool.merch.tests\` (19 tests pass, including new coverage)
- [x] Browser-tested end-to-end on a local-prod-parity stack (Postgres 18, CMS 5): single-qty and multi-qty merch-only checkouts redirect straight to \`/registration/summary/\`