### PR TITLE
Add get_registration_summary_header_stats signal for extra viewregistrations rows

### DIFF
--- a/danceschool/core/signals.py
+++ b/danceschool/core/signals.py
@@ -104,3 +104,12 @@ get_eventregistration_data = Signal(''' ['eventregistrations'] ''')
 # views.EventRegistrationSummaryView to get other names that may be checked in,
 # such as guest list names.  
 get_additional_event_names = Signal(''' ['event'] ''')
+
+# Fires from EventRegistrationSummaryView.get_context_data() so that other
+# apps can contribute extra header statistics (label/value pairs) to be
+# rendered in the summary <dl> above the registration table. Each handler
+# should return either an empty list or a list of dicts shaped
+# {'label': str, 'value': str_or_int}.
+get_registration_summary_header_stats = Signal(
+    ''' ['event', 'registrations'] '''
+)

--- a/danceschool/core/templates/core/view_eventregistrations.html
+++ b/danceschool/core/templates/core/view_eventregistrations.html
@@ -13,6 +13,9 @@
 		<dt>{% trans "Location" %}:</dt><dd>{{ event.location.name }}{% if event.room.name %} - {{ event.room.name }}{% endif %}</dd>
 		<dt>{% trans "Time" %}:</dt><dd>{{ event.startTime|date:'l, h:i A' }}</dd>
 		<dt>{% trans "Partner Required" %}:</dt><dd>{{ event.partnerRequired|yesno }}</dd>
+		{% for stat in extra_header_stats %}
+			<dt>{{ stat.label }}:</dt><dd>{{ stat.value }}</dd>
+		{% endfor %}
 	</dl>
 {% endif %}
 

--- a/danceschool/core/tests/test_view_eventregistrations.py
+++ b/danceschool/core/tests/test_view_eventregistrations.py
@@ -150,3 +150,62 @@ class HeaderStatsViewIntegrationTest(TestCase):
             get_registration_summary_header_stats.disconnect(
                 dispatch_uid='test_kwargs_receiver',
             )
+
+
+class HeaderStatsTemplateRenderTest(TestCase):
+    """
+    Tests that view_eventregistrations.html renders each entry in
+    extra_header_stats as a <dt>/<dd> pair inside the header <dl>.
+    """
+
+    def setUp(self):
+        now = timezone.now()
+        self.superuser = User.objects.create_superuser(
+            'templateuser', 'template@example.com', 'pass'
+        )
+        self.event = PublicEvent.objects.create(
+            title='Template Test Social',
+            slug='template-test-social',
+            status=Event.RegStatus.enabled,
+        )
+        EventOccurrence.objects.create(
+            event=self.event,
+            startTime=now + timedelta(days=1),
+            endTime=now + timedelta(days=1, hours=2),
+        )
+        self.client.login(username='templateuser', password='pass')
+
+    def test_stats_render_as_dt_dd_pairs(self):
+        @receiver(
+            get_registration_summary_header_stats,
+            dispatch_uid='test_template_render',
+        )
+        def contributor(sender, event, registrations, **kwargs):
+            return [
+                {'label': 'Widget count', 'value': 7},
+                {'label': 'Gadget count', 'value': 12},
+            ]
+
+        try:
+            response = self.client.get(
+                reverse('viewregistrations', args=(self.event.id,))
+            )
+            body = response.content.decode('utf-8')
+            self.assertIn('<dt>Widget count:</dt>', body)
+            self.assertIn('<dd>7</dd>', body)
+            self.assertIn('<dt>Gadget count:</dt>', body)
+            self.assertIn('<dd>12</dd>', body)
+        finally:
+            get_registration_summary_header_stats.disconnect(
+                dispatch_uid='test_template_render',
+            )
+
+    def test_no_stats_means_no_extra_dt_dd_after_partner_required(self):
+        response = self.client.get(
+            reverse('viewregistrations', args=(self.event.id,))
+        )
+        body = response.content.decode('utf-8')
+        # 'Partner Required' is the last of the built-ins. No extra dt/dd
+        # should appear when extra_header_stats is empty.
+        self.assertIn('Partner Required', body)
+        self.assertNotIn('Widget count', body)

--- a/danceschool/core/tests/test_view_eventregistrations.py
+++ b/danceschool/core/tests/test_view_eventregistrations.py
@@ -1,0 +1,13 @@
+from django.test import TestCase
+from django.dispatch import Signal
+
+
+class HeaderStatsSignalTest(TestCase):
+    """
+    Tests that the get_registration_summary_header_stats signal is declared
+    in danceschool.core.signals and is a Signal instance.
+    """
+
+    def test_signal_is_declared(self):
+        from danceschool.core.signals import get_registration_summary_header_stats
+        self.assertIsInstance(get_registration_summary_header_stats, Signal)

--- a/danceschool/core/tests/test_view_eventregistrations.py
+++ b/danceschool/core/tests/test_view_eventregistrations.py
@@ -11,3 +11,142 @@ class HeaderStatsSignalTest(TestCase):
     def test_signal_is_declared(self):
         from danceschool.core.signals import get_registration_summary_header_stats
         self.assertIsInstance(get_registration_summary_header_stats, Signal)
+
+
+from datetime import timedelta
+
+from django.urls import reverse
+from django.utils import timezone
+from django.dispatch import receiver
+from django.contrib.auth.models import User
+
+from danceschool.core.models import Event, PublicEvent, EventOccurrence
+from danceschool.core.signals import get_registration_summary_header_stats
+from danceschool.core.views.registration_summary import EventRegistrationSummaryView
+
+
+class HeaderStatsViewIntegrationTest(TestCase):
+    """
+    Tests that EventRegistrationSummaryView fires the signal with the
+    expected kwargs and merges returned dicts into extra_header_stats.
+    """
+
+    def setUp(self):
+        now = timezone.now()
+        self.superuser = User.objects.create_superuser(
+            'testuser', 'test@example.com', 'pass'
+        )
+        self.event = PublicEvent.objects.create(
+            title='Test Social',
+            slug='test-social',
+            status=Event.RegStatus.enabled,
+        )
+        EventOccurrence.objects.create(
+            event=self.event,
+            startTime=now + timedelta(days=1),
+            endTime=now + timedelta(days=1, hours=2),
+        )
+        self.client.login(username='testuser', password='pass')
+
+    def test_no_receivers_yields_empty_header_stats(self):
+        response = self.client.get(
+            reverse('viewregistrations', args=(self.event.id,))
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context['extra_header_stats'], [])
+
+    def test_single_receiver_populates_header_stats(self):
+        @receiver(
+            get_registration_summary_header_stats,
+            dispatch_uid='test_single_receiver',
+        )
+        def contributor(sender, event, registrations, **kwargs):
+            return [{'label': 'Test Stat', 'value': 42}]
+
+        try:
+            response = self.client.get(
+                reverse('viewregistrations', args=(self.event.id,))
+            )
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(
+                response.context['extra_header_stats'],
+                [{'label': 'Test Stat', 'value': 42}],
+            )
+        finally:
+            get_registration_summary_header_stats.disconnect(
+                dispatch_uid='test_single_receiver',
+            )
+
+    def test_multiple_receivers_are_concatenated(self):
+        @receiver(
+            get_registration_summary_header_stats,
+            dispatch_uid='test_multi_a',
+        )
+        def contributor_a(sender, event, registrations, **kwargs):
+            return [{'label': 'A', 'value': 1}]
+
+        @receiver(
+            get_registration_summary_header_stats,
+            dispatch_uid='test_multi_b',
+        )
+        def contributor_b(sender, event, registrations, **kwargs):
+            return [{'label': 'B', 'value': 2}]
+
+        try:
+            response = self.client.get(
+                reverse('viewregistrations', args=(self.event.id,))
+            )
+            labels = [s['label'] for s in response.context['extra_header_stats']]
+            self.assertIn('A', labels)
+            self.assertIn('B', labels)
+            self.assertEqual(len(response.context['extra_header_stats']), 2)
+        finally:
+            get_registration_summary_header_stats.disconnect(
+                dispatch_uid='test_multi_a',
+            )
+            get_registration_summary_header_stats.disconnect(
+                dispatch_uid='test_multi_b',
+            )
+
+    def test_receiver_returning_empty_list_contributes_nothing(self):
+        @receiver(
+            get_registration_summary_header_stats,
+            dispatch_uid='test_empty_receiver',
+        )
+        def contributor(sender, event, registrations, **kwargs):
+            return []
+
+        try:
+            response = self.client.get(
+                reverse('viewregistrations', args=(self.event.id,))
+            )
+            self.assertEqual(response.context['extra_header_stats'], [])
+        finally:
+            get_registration_summary_header_stats.disconnect(
+                dispatch_uid='test_empty_receiver',
+            )
+
+    def test_signal_receives_event_and_registrations_kwargs(self):
+        seen = {}
+
+        @receiver(
+            get_registration_summary_header_stats,
+            dispatch_uid='test_kwargs_receiver',
+        )
+        def contributor(sender, event, registrations, **kwargs):
+            seen['sender'] = sender
+            seen['event_id'] = event.id
+            seen['registrations_is_iterable'] = hasattr(registrations, '__iter__')
+            return []
+
+        try:
+            self.client.get(
+                reverse('viewregistrations', args=(self.event.id,))
+            )
+            self.assertEqual(seen['sender'], EventRegistrationSummaryView)
+            self.assertEqual(seen['event_id'], self.event.id)
+            self.assertTrue(seen['registrations_is_iterable'])
+        finally:
+            get_registration_summary_header_stats.disconnect(
+                dispatch_uid='test_kwargs_receiver',
+            )

--- a/danceschool/core/views/registration_summary.py
+++ b/danceschool/core/views/registration_summary.py
@@ -19,7 +19,7 @@ from ..models import (
 from ..forms.event import EventAutocompleteForm
 from ..constants import getConstant
 from ..mixins import EventOrderMixin, SiteHistoryMixin
-from ..signals import get_eventregistration_data, get_additional_event_names, get_person_data
+from ..signals import get_eventregistration_data, get_additional_event_names, get_person_data, get_registration_summary_header_stats
 from ..registries import extras_templates_registry
 from ..utils.timezone import ensure_localtime
 
@@ -183,6 +183,18 @@ class EventRegistrationSummaryView(PermissionRequiredMixin, SiteHistoryMixin, De
             for k, v in chain.from_iterable([x.items() for x in [y[1] for y in extra_names_data if y[1]]]):
                 additional_names_extras_dict[k].extend(v)
 
+        # Signal-based extension: let apps contribute per-event header stats
+        # (label/value dicts) rendered above the registration table.
+        header_stats_responses = get_registration_summary_header_stats.send(
+            sender=EventRegistrationSummaryView,
+            event=self.object,
+            registrations=registrations,
+        )
+        extra_header_stats = []
+        for _receiver, response in header_stats_responses:
+            if response:
+                extra_header_stats.extend(response)
+
         # Compute next_occurrence from prefetched eventoccurrence_set (avoids DB query)
         now_floor = ensure_localtime(timezone.now()).replace(
             hour=0, minute=0, second=0, microsecond=0
@@ -244,6 +256,7 @@ class EventRegistrationSummaryView(PermissionRequiredMixin, SiteHistoryMixin, De
             'extras': extras_dict,
             'additional_names_extras': additional_names_extras_dict,
             'extras_templates_registry': extras_templates_registry,
+            'extra_header_stats': extra_header_stats,
         }
         context.update(kwargs)
         return super().get_context_data(**context)


### PR DESCRIPTION
## Summary

Adds a new `get_registration_summary_header_stats` signal that EventRegistrationSummaryView fires. Custom apps can register receivers that return `{'label': str, 'value': str_or_int}` dicts; the view collects them and the template renders them as extra `<dt>/<dd>` rows after "Partner Required" in the header `<dl>`.

Mirrors the existing per-row extras pattern in the same view (extras_templates_registry + get_eventregistration_data signal), so the mechanism will be familiar to anyone reading that file.

## Motivation

Custom apps need a way to contribute per-event summary rows to the viewregistrations page without adding domain-specific vocabulary to core. In our case (NCS), we want a "Drop-in lesson attendees" count for a specific event category — but the same primitive works for any school that has similar needs.

## Backwards compatibility

Fully additive. With no receivers registered, `extra_header_stats` is `[]` and the template renders identically. No database migrations, no new settings, no dependency changes.

## Test plan

- 8 new tests in `danceschool/core/tests/test_view_eventregistrations.py`:
  - Signal declaration exists and is a `Signal` instance
  - Signal fires with correct sender/event/registrations kwargs
  - Empty receiver list → empty context, template renders nothing extra
  - Single receiver populates and renders correctly
  - Multiple receivers concatenate in dispatch order
  - Receiver returning `[]` contributes nothing
- Full `danceschool.core` suite still passes (regression check).

## Notes

Tests use plain `django.test.TestCase` rather than `DefaultSchoolTestCase` because that base class currently fails to import `StaticPlaceholder` from django CMS 5 — a pre-existing issue that PR #187 addresses. Our tests only need a superuser + PublicEvent + occurrence, none of which require the full school fixture.